### PR TITLE
Fix typo in index.md of generative testing.

### DIFF
--- a/clojure-spec/generative-testing/index.md
+++ b/clojure-spec/generative-testing/index.md
@@ -26,7 +26,7 @@ https://youtu.be/xZQ7p-YBHtE
 
 ## References
 * [Clojure.org guides: Spec - Generators](https://clojure.org/guides/spec#_generators)
-* [API reference: clojure.spec.test.alpha](https://clojure.github.io/spec.alpha/clojure.spec.gen.alpha-api.html)
+* [API reference: clojure.spec.gen.alpha](https://clojure.github.io/spec.alpha/clojure.spec.gen.alpha-api.html)
 * [API reference: clojure.spec.test.alpha](https://clojure.github.io/spec.alpha/clojure.spec.test.alpha-api.html)
 * [Video: How to do Stateful Property Testing in Clojure?](https://www.youtube.com/watch?v=xw8ZFU8CGdA)
 


### PR DESCRIPTION
Fix a typo in the description of the link to the API for clojure.spec.gen.alpha.