### PR TITLE
docs: fix typo in introduction

### DIFF
--- a/docs/introduction/clojure-in-15-minutes.md
+++ b/docs/introduction/clojure-in-15-minutes.md
@@ -153,7 +153,7 @@ A predicate is a function that returns a boolean `true` or `false` value and by 
 The most common data collections in Clojure:
 
 * `(1 2 "three")` or `(list 1 2 "three")` - a list of values read from start to end (sequential access)
-* `[1 2 "three"]` or `(list 1 2 "three")` - a vector of values with index (random access)
+* `[1 2 "three"]` or `(vector 1 2 "three")` - a vector of values with index (random access)
 * `{:key "value"}` or `(hash-map :key "value")` - a hash-map with zero or more key value pairs (associative relation)
 * `#{1 2 "three"}` or `(set 1 2 "three")` - a unique set of values
 


### PR DESCRIPTION
:memo: Description

This PR fixes a small typo in the introduction part.

* `[1 2 "three"]` or ~~`(list 1 2 "three")`~~ - a vector of values with index (random access)
* `[1 2 "three"]` or **`(vector 1 2 "three")`** - a vector of values with index (random access)

:white_check_mark: Checklist

- [x] Commits should be cryptographically signed (SSH or GPG)


## Practicalli Guidelines

Please follow these guidelines when submitting a pull request

- refer to all relevant issues, using `#` followed by the issue number (or paste full link to the issue)
- PR should contain the smallest possible change
- PR should contain a very specific change
- PR should contain only a single commit (squash your commits locally if required)
- Avoid multiple changes across multiple files (raise an issue so we can discuss)
- Avoid a long list of spelling or grammar corrections.  These take too long to review and cherry pick.

## Submitting articles

[Create an issue using the article template](https://github.com/practicalli/blog-content/issues/new?assignees=&labels=article&template=article.md&title=Suggested+article+title),
providing as much detail as possible.

## Website design

Suggestions about website design changes are most welcome, especially in terms of usability and accessibility.

Please raise an issue so we can discuss changes first, especially changes related to aesthetics.

## Review process

All pull requests are reviewed by @practicalli-johnny and feedback provided, usually the same day but please be patient.
